### PR TITLE
Fix did:x509 generation

### DIFF
--- a/pkg/cosesign1/Makefile
+++ b/pkg/cosesign1/Makefile
@@ -17,7 +17,7 @@ cose: infra.rego.cose
 #     fragment atrifact type = application/unknown+rego
 #     fragment media type = application/microsoft.security.policy+rego
 
-sign1util: ../../internal/tools/sign1util/main.go
+sign1util: ../../internal/tools/sign1util/main.go *.go
 	go build ../../internal/tools/sign1util
 
 infra.rego.cose: infra.rego.base64 chain.pem leaf.private.pem sign1util
@@ -28,7 +28,7 @@ print: infra.rego.cose sign1util
 	./sign1util print -in $<
 
 didx509: chain.pem sign1util
-	@./sign1util did:x509 -chain chain.pem -i 1 -policy "subject:CN:Test Root CA (DO NOT TRUST)"
+	./sign1util did:x509 -chain chain.pem -i 1 -policy "subject:CN:Test Leaf (DO NOT TRUST)" -verbose
 
 oras: infra.rego.cose
 	oras push ${REGISTRY}/${INFRA_REPO}:latest \

--- a/pkg/cosesign1/Makefile.certs
+++ b/pkg/cosesign1/Makefile.certs
@@ -8,9 +8,7 @@ all: chain.pem
 
 root.cert.pem: root.private.pem
 	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
-	openssl req -in $@.tmp.csr -text -noout
 	openssl x509 -req -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
-	openssl x509 -in $@ -text -noout
 	rm -rf $@.tmp.csr
 
 intermediate.cert.pem: intermediate.private.pem | root.private.pem

--- a/pkg/cosesign1/Makefile.certs
+++ b/pkg/cosesign1/Makefile.certs
@@ -7,13 +7,15 @@ all: chain.pem
 	openssl ec -in $< -pubout -out $@
 
 root.cert.pem: root.private.pem
-	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext basicConstraints=CA:TRUE
-	openssl x509 -req -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial
+	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Root CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
+	openssl req -in $@.tmp.csr -text -noout
+	openssl x509 -req -days 365 -in $@.tmp.csr -signkey $< -out $@ -CAcreateserial -extfile cert.extensions.cfg
+	openssl x509 -in $@ -text -noout
 	rm -rf $@.tmp.csr
 
 intermediate.cert.pem: intermediate.private.pem | root.private.pem
-	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Intermediate CA (DO NOT TRUST)" -addext basicConstraints=CA:TRUE
-	openssl x509 -req -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial
+	openssl req -new -key $< -out $@.tmp.csr -subj "/CN=Test Intermediate CA (DO NOT TRUST)" -addext 'basicConstraints=critical,CA:TRUE' -addext 'keyUsage=digitalSignature,keyCertSign' 
+	openssl x509 -req -days 365 -in $@.tmp.csr -CA ${subst private,cert,$|} -CAkey $| -out $@ -CAcreateserial -extfile cert.extensions.cfg
 	rm $@.tmp.csr
 
 leaf.cert.pem: leaf.private.pem | intermediate.private.pem

--- a/pkg/cosesign1/cert.extensions.cfg
+++ b/pkg/cosesign1/cert.extensions.cfg
@@ -1,0 +1,2 @@
+basicConstraints=critical,CA:TRUE
+keyUsage=digitalSignature,keyCertSign

--- a/pkg/cosesign1/cosesign1util_test.go
+++ b/pkg/cosesign1/cosesign1util_test.go
@@ -47,6 +47,10 @@ func comparePEMs(pk1pem string, pk2pem string) bool {
 	return bytes.Equal(pk1der, pk2der)
 }
 
+/*
+	Decode a COSE_Sign1 document and check that we get the expected payload, issuer, keys, certs etc.
+*/
+
 func Test_UnpackAndValidateCannedFragment(t *testing.T) {
 	var unpacked UnpackedCoseSign1
 	unpacked, err := UnpackAndValidateCOSE1CertChain(FragmentCose, nil, nil, false, false)

--- a/pkg/cosesign1/cosesign1util_test.go
+++ b/pkg/cosesign1/cosesign1util_test.go
@@ -41,6 +41,12 @@ func comparePEMs(pk1pem string, pk2pem string) bool {
 	Decode a COSE_Sign1 document and check that we get the expected payload, issuer, keys, certs etc.
 */
 
+func comparePEMs(pk1pem string, pk2pem string) bool {
+	pk1der := pem2der([]byte(pk1pem))
+	pk2der := pem2der([]byte(pk2pem))
+	return bytes.Equal(pk1der, pk2der)
+}
+
 func Test_UnpackAndValidateCannedFragment(t *testing.T) {
 	var unpacked UnpackedCoseSign1
 	unpacked, err := UnpackAndValidateCOSE1CertChain(FragmentCose, nil, nil, false, false)

--- a/pkg/cosesign1/cosesign1util_test.go
+++ b/pkg/cosesign1/cosesign1util_test.go
@@ -41,16 +41,6 @@ func comparePEMs(pk1pem string, pk2pem string) bool {
 	Decode a COSE_Sign1 document and check that we get the expected payload, issuer, keys, certs etc.
 */
 
-func comparePEMs(pk1pem string, pk2pem string) bool {
-	pk1der := pem2der([]byte(pk1pem))
-	pk2der := pem2der([]byte(pk2pem))
-	return bytes.Equal(pk1der, pk2der)
-}
-
-/*
-	Decode a COSE_Sign1 document and check that we get the expected payload, issuer, keys, certs etc.
-*/
-
 func Test_UnpackAndValidateCannedFragment(t *testing.T) {
 	var unpacked UnpackedCoseSign1
 	unpacked, err := UnpackAndValidateCOSE1CertChain(FragmentCose, nil, nil, false, false)
@@ -131,6 +121,14 @@ func Test_OldCose(t *testing.T) {
 	if err != nil {
 		t.Errorf("validation of %s failed", filename)
 	}
+}
+
+func Test_DidX509(t *testing.T) {
+	didx509, err := MakeDidX509("sha256", 1, "chain.pem", "subject:CN:Test Leaf (DO NOT TRUST)", true)
+	if err != nil {
+		t.Errorf("did:x509 creation failed: %s", err)
+	}
+	print(didx509)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/cosesign1/misc.go
+++ b/pkg/cosesign1/misc.go
@@ -91,15 +91,15 @@ single line base64 standard encoded raw DER certificate
 // 	return base64CertToPEM(base64Cert)
 // }
 
-func base64CertToPEM(base64Cert string) string {
+// func base64CertToPEM(base64Cert string) string {
 
-	var begin = "-----BEGIN CERTIFICATE-----\n"
-	var end = "\n-----END CERTIFICATE-----"
+// 	var begin = "-----BEGIN CERTIFICATE-----\n"
+// 	var end = "\n-----END CERTIFICATE-----"
 
-	pemData := begin + base64Cert + end
+// 	pemData := begin + base64Cert + end
 
-	return pemData
-}
+// 	return pemData
+// }
 
 // func keyToPEM(key any) string {
 
@@ -107,15 +107,15 @@ func base64CertToPEM(base64Cert string) string {
 // 	return base64PublicKeyToPEM(base64Key)
 // }
 
-func base64PublicKeyToPEM(base64Key string) string {
+// func base64PublicKeyToPEM(base64Key string) string {
 
-	var begin = "-----BEGIN PUBLIC KEY-----\n"
-	var end = "\n-----END PUBLIC KEY-----"
+// 	var begin = "-----BEGIN PUBLIC KEY-----\n"
+// 	var end = "\n-----END PUBLIC KEY-----"
 
-	pemData := begin + base64Key + end
+// 	pemData := begin + base64Key + end
 
-	return pemData
-}
+// 	return pemData
+// }
 
 // func logCert(name string, x509cert *x509.Certificate) {
 // 	log.Printf("%s:\n", name)

--- a/pkg/cosesign1/misc.go
+++ b/pkg/cosesign1/misc.go
@@ -91,15 +91,15 @@ single line base64 standard encoded raw DER certificate
 // 	return base64CertToPEM(base64Cert)
 // }
 
-// func base64CertToPEM(base64Cert string) string {
+func base64CertToPEM(base64Cert string) string {
 
-// 	var begin = "-----BEGIN CERTIFICATE-----\n"
-// 	var end = "\n-----END CERTIFICATE-----"
+	var begin = "-----BEGIN CERTIFICATE-----\n"
+	var end = "\n-----END CERTIFICATE-----"
 
-// 	pemData := begin + base64Cert + end
+	pemData := begin + base64Cert + end
 
-// 	return pemData
-// }
+	return pemData
+}
 
 // func keyToPEM(key any) string {
 
@@ -107,15 +107,15 @@ single line base64 standard encoded raw DER certificate
 // 	return base64PublicKeyToPEM(base64Key)
 // }
 
-// func base64PublicKeyToPEM(base64Key string) string {
+func base64PublicKeyToPEM(base64Key string) string {
 
-// 	var begin = "-----BEGIN PUBLIC KEY-----\n"
-// 	var end = "\n-----END PUBLIC KEY-----"
+	var begin = "-----BEGIN PUBLIC KEY-----\n"
+	var end = "\n-----END PUBLIC KEY-----"
 
-// 	pemData := begin + base64Key + end
+	pemData := begin + base64Key + end
 
-// 	return pemData
-// }
+	return pemData
+}
 
 // func logCert(name string, x509cert *x509.Certificate) {
 // 	log.Printf("%s:\n", name)


### PR DESCRIPTION
`make didx509` now creates a did:x509 string from `chain.pem` and successfully verifies it.